### PR TITLE
Rtabmap new noetic interface

### DIFF
--- a/racecar_behaviors/launch/blob_detection.launch
+++ b/racecar_behaviors/launch/blob_detection.launch
@@ -14,7 +14,7 @@
        <remap from="/scan" to="scan"/>
     </node>
     <!-- register scan to camera -->
-    <node pkg="rtabmap_ros" type="pointcloud_to_depthimage" name="pointcloud_to_depthimage">
+    <node pkg="rtabmap_util" type="pointcloud_to_depthimage" name="pointcloud_to_depthimage">
        <param name="fixed_frame_id"  value="$(arg prefix)/odom"/>
        <param name="fill_holes_size" value="2"/>
        <remap from="camera_info" to="raspicam_node/camera_info"/>
@@ -35,7 +35,7 @@
         
     <!-- used to debug camera vs scan registration -->
     <group if="$(arg debug)">
-       <node pkg="nodelet" type="nodelet" name="point_cloud_xyzrgb" args="standalone rtabmap_ros/point_cloud_xyzrgb">
+       <node pkg="nodelet" type="nodelet" name="point_cloud_xyzrgb" args="standalone rtabmap_util/point_cloud_xyzrgb">
           <param name="approx_sync"  value="false"/>
           <remap from="cloud"           to="raspicam_node/registered_cloud"/>
           <remap from="depth/image"     to="raspicam_node/depth_registered_raw"/>

--- a/racecar_bringup/config/bringup.rviz
+++ b/racecar_bringup/config/bringup.rviz
@@ -189,7 +189,7 @@ Visualization Manager:
         - Alpha: 1
           Class: rviz/RobotModel
           Collision Enabled: false
-          Enabled: true
+          Enabled: false
           Links:
             All Links Enabled: true
             Expand Joint Details: false

--- a/racecar_bringup/config/bringup.rviz
+++ b/racecar_bringup/config/bringup.rviz
@@ -189,7 +189,7 @@ Visualization Manager:
         - Alpha: 1
           Class: rviz/RobotModel
           Collision Enabled: false
-          Enabled: false
+          Enabled: true
           Links:
             All Links Enabled: true
             Expand Joint Details: false

--- a/racecar_navigation/config/global_costmap_params.yaml
+++ b/racecar_navigation/config/global_costmap_params.yaml
@@ -7,7 +7,7 @@ global_costmap:
  
   transform_tolerance: 0.5
   plugins:
-    - {name: static_layer,            type: "rtabmap_ros::StaticLayer"}
+    - {name: static_layer,            type: "rtabmap_costmap_plugins::StaticLayer"}
     - {name: inflation_layer,         type: "costmap_2d::InflationLayer"}
 
 

--- a/racecar_navigation/config/rviz_navigation.rviz
+++ b/racecar_navigation/config/rviz_navigation.rviz
@@ -63,7 +63,7 @@ Visualization Manager:
       Use Timestamp: false
       Value: true
     - Alpha: 1
-      Class: rtabmap_ros/MapGraph
+      Class: rtabmap_rviz_plugins/MapGraph
       Enabled: true
       Global loop closure: 255; 0; 0
       Local loop closure: 255; 255; 0

--- a/racecar_navigation/launch/slam.launch
+++ b/racecar_navigation/launch/slam.launch
@@ -11,7 +11,7 @@
   <group ns="$(arg prefix)">
     
     <!-- Mapping: -->
-    <node name="rtabmap" pkg="rtabmap_ros" type="rtabmap" output="screen" args="$(arg rtabmap_args) --uerror">
+    <node name="rtabmap" pkg="rtabmap_slam" type="rtabmap" output="screen" args="$(arg rtabmap_args) --uerror">
       <param name="database_path" type="string" value="$(arg database_path)"/>
       <param name="frame_id" type="string" value="$(arg prefix)/base_footprint"/>
       <param name="map_frame_id" type="string" value="$(arg prefix)/map"/>


### PR DESCRIPTION
Le paquet `rtabmap_ros` est maintenant décomposé en sous-paquets, voir [ros wiki officiel](http://wiki.ros.org/rtabmap_ros#rtabmap_ros.2Fnoetic_and_newer.Migration_Guide_New_Interface_Noetic.2FROS2).

Ce PR met à jour les références à rtabmap pour noetic (l'interface melodic n'a pas été changé, puisque ubuntu 18.04 est EOL). 

À celui qui est en charge du support pour le code, faudrait mettre à jour l'image de la carte SD pour Noetic sur cette [page](https://github.com/SherbyRobotics/racecar/tree/master/images) (pour utiliser la nouvelle interrface de rtabmap). Sans recommencer l'image à partir de zéro, juste faire un `sudo apt upgrade -y` va permettre de mettre tout à jour, puis refaire l'image de la carte carte SD suivant la section [Backup/Shrink](https://github.com/SherbyRobotics/racecar/tree/master/images#backupshrink-raspberrypi-image)