### PR TITLE
Fix blob detector example

### DIFF
--- a/racecar_behaviors/launch/blob_detection.launch.py
+++ b/racecar_behaviors/launch/blob_detection.launch.py
@@ -24,14 +24,15 @@ def launch_setup(context, *args, **kwargs):
         package='racecar_behaviors',
         executable='laserscan_to_pointcloud',
         name='laserscan_to_pointcloud',
-        remappings=[('/scan', '/racecar/scan'), ('converted_pc', 'scan_cloud')]
+        remappings=[('/scan', '/racecar/scan'), ('converted_pc', 'scan_cloud')],
+        arguments=["--ros-args", "--log-level", 'laserscan_to_pointcloud:=warn']
     )
 
     pointcloud_to_depthimage_node = Node(
         package='rtabmap_util',
         executable='pointcloud_to_depthimage',
         name='pointcloud_to_depthimage',
-        parameters=[{'fixed_frame_id': 'racecar/odom', 'fill_holes_size': 2}],
+        parameters=[{'fixed_frame_id': 'racecar/odom', 'fill_holes_size': 4, 'topic_queue_size': 10}],
         remappings=[('camera_info', 'racecar/camera_info'), ('cloud', 'scan_cloud'),
                     ('image', 'raspicam_node/depth_registered'), ('image_raw', 'raspicam_node/depth_registered_raw')]
     )

--- a/racecar_description/urdf/racecar.gazebo
+++ b/racecar_description/urdf/racecar.gazebo
@@ -147,6 +147,7 @@
         <mean>0.0</mean>
         <stddev>0.007</stddev>
       </noise>
+      <ignition_frame_id>$(arg prefix)/camera_optical_link</ignition_frame_id>
     </sensor>
   </gazebo>
 </xacro:unless>


### PR DESCRIPTION
The PR fixes issues about blob_detector basic example not working on ROS2. It has been tested only in simulation and on ROS2 Humble. I refactored to match more the code from ROS1, like using message_filters to sync image, depth and info.

Expected results in rviz2. Images on left in order: 
 * image from the camera
 * depth image generated by pointcloud_to_depthimage node, which is the reprojection of the laser scan on the camera. This is used in blob_detector to estimate the depth of the blob (corresponding pixels).
 * the image detection image from blob detector
![Screenshot from 2024-11-20 22-38-26](https://github.com/user-attachments/assets/ad6f5e4f-adfa-444f-a43a-091ab78e8d67)

On terminal, we should see this status when a blob is detected:
```
[blob_detector-4] [INFO] [1732172131.384570381] [blob_detector]: Object detected at [1.216688138844317,3.3555876892119465] in racecar/odom frame! Distance and direction from robot: 1.7248605443740235m 2.4534590547912525deg.
[blob_detector-4] [INFO] [1732172131.485599171] [blob_detector]: Object detected at [1.195563089867614,3.3739905972642616] in racecar/odom frame! Distance and direction from robot: 1.7528520051320973m 2.4141860160641517deg.
[blob_detector-4] [INFO] [1732172131.587513851] [blob_detector]: Object detected at [1.1921571373960254,3.376957664002631] in racecar/odom frame! Distance and direction from robot: 1.7573650917012802m 2.4079715263682013deg.
```