### PR TITLE
add setup file

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -57,3 +57,20 @@ If your are configuring a native Ubuntu 22.04 computer skip to step 6. If you wa
     $ ./setup_vm_ubuntu2204_humble.bash
     ```
 
+# Setup RPI5 from scratch
+
+1. Download the official ubuntu 24.04 image for RPI:
+    * RPI5 and RPI4: [ubuntu24.04](https://ubuntu.com/download/raspberry-pi)
+2. Use [Etcher](https://www.balena.io/etcher/) to flash the image on a SD-CARD (min 16GB). 
+
+3. Boot the RPI with HDMI, a mouse and a keyboard connected. Create a user with name `racecar` and password is `racecar`.
+
+4. Make sure the RPI have internet acces.
+
+5. Download and launch the install script for RPI.
+
+    ```bash
+    $ wget https://raw.githubusercontent.com/SherbyRobotics/racecar/ros2/images/setup_rpi5_ubuntu2404_jazzy.bash
+    $ chmod +x setup_rpi5_ubuntu2404_jazzy.bash
+    $ ./setup_rpi5_ubuntu2404_jazzy.bash
+    ```

--- a/images/setup_rpi5_ubuntu2404_jazzy.bash
+++ b/images/setup_rpi5_ubuntu2404_jazzy.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Download update
+sudo apt update && sudo apt upgrade -y
+
+# Configure remote access
+sudo apt install -y openssh-server xrdp
+
+# Enable to GPU
+sudo usermod -a -G render $USER
+
+# Add swap
+sudo fallocate -l 8G /extra-swapfile
+sudo chmod 600 /extra-swapfile
+sudo mkswap /extra-swapfile
+sudo swapon /extra-swapfile
+sudo echo "/extra-swapfile swap swap defaults 0 0" | sudo tee -a /etc/fstab
+
+# configure Hotspot
+sudo nmcli device wifi hotspot ssid racecar_x password racecar_x ifname wlan0
+sudo nmcli connection modify Hotspot connection.autoconnect yes connection.autoconnect-priority 100
+
+
+# Configure ROS environment
+wget https://raw.githubusercontent.com/SherbyRobotics/racecar/ros2/images/setup_vm_ubuntu2404_jazzy.bash
+chmod +x setup_vm_ubuntu2404_jazzy.bash
+./setup_vm_ubuntu2404_jazzy.bash
+
+sudo reboot

--- a/images/setup_rpi5_ubuntu2404_jazzy.bash
+++ b/images/setup_rpi5_ubuntu2404_jazzy.bash
@@ -6,8 +6,10 @@ sudo apt update && sudo apt upgrade -y
 # Configure remote access
 sudo apt install -y openssh-server xrdp
 
-# Enable to GPU
+# Add user to groups
 sudo usermod -a -G render $USER
+sudo usermod -a -G video $USER
+sudo usermod -a -G dialout $USER
 
 # Add swap
 sudo fallocate -l 8G /extra-swapfile

--- a/images/setup_vm_ubuntu2404_jazzy.bash
+++ b/images/setup_vm_ubuntu2404_jazzy.bash
@@ -12,8 +12,27 @@ sudo apt-get install -y --no-install-recommends \
     net-tools \
     nmap \
     htop \
-    git
+    git \
+    wget \
+    gpg \
+    python3-venv
     # Add your packages here
+
+
+# Install vscode and extention
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
+sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
+echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" |sudo tee /etc/apt/sources.list.d/vscode.list > /dev/null
+rm -f packages.microsoft.gpg
+
+sudo apt install -y apt-transport-https
+sudo apt update
+sudo apt install -y code
+
+code --install-extension platformio.platformio-ide
+code --install-extension ms-vscode-remote.vscode-remote-extensionpack
+code --install-extension ms-iot.vscode-ros
+
 
 # === Install ROS ===
 

--- a/racecar_bringup/package.xml
+++ b/racecar_bringup/package.xml
@@ -11,6 +11,7 @@
   <exec_depend>racecar_web_interface</exec_depend>
   <exec_depend>web_video_server</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>v4l2_camera</exec_depend>
   <depend>rplidar_ros</depend>
   <depend>tf_transformations</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
This PR address the following issue #11 #12 

It make a repeatable installation process for the RPI5 by : 

- installing ROS
- Adding a swapfile
- give driver permission
- pulling the racecar code
- installing a ssh-server
- installing utils
- installing a remote destop client
- setuping the hotspot