### PR TITLE
Add "Band-Aid" for GRO830's lab issue with `blob_detector`

### DIFF
--- a/doc/gro830-lab-a25.md
+++ b/doc/gro830-lab-a25.md
@@ -43,7 +43,7 @@ source .venv/bin/activate  # Activate the virtual environment
 Once the virtual environment is activated, install the dependencies:
 
 ```bash
-pip3 install --requirement src/racecar/gro830_lab.txt
+pip3 install --requirement src/racecar/gro830-lab.txt
 ```
 
 Verify the installation worked with `pip3 list | grep transforms3D`. The version SHOULD be `0.4.2`.

--- a/racecar_behaviors/racecar_behaviors/blob_detector.py
+++ b/racecar_behaviors/racecar_behaviors/blob_detector.py
@@ -1,5 +1,10 @@
     #!/usr/bin/env python3
 
+# Band-Aid to be able to use `ros2 launch`
+import sys
+if "/usr/local/lib/python3.12/dist-packages" in sys.path:
+    sys.path.remove("/usr/local/lib/python3.12/dist-packages")
+
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile


### PR DESCRIPTION
This commit adds a "Band-Aid" for (temporarily) fixing the issue with the lab PCs' "bad" version of NumPy used when executing the `blob_detector` script in GRO830's lab. This is the same issue as the one with `labo_brushfire`, but because `blob_detector` is executed using a launch file, using `python3` to execute the script is kind of a PITA.

The fix makes it so `ros2 launch` avoids the error.

Additionally, this commit changes a typo in the documentation of #40.