### PR TITLE
Fix Gazebo resource path issue for GRO830`s lab.

### DIFF
--- a/racecar_gazebo/launch/racecar_circuit.launch.py
+++ b/racecar_gazebo/launch/racecar_circuit.launch.py
@@ -3,7 +3,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.actions import AppendEnvironmentVariable, SetEnvironmentVariable
+from launch.actions import AppendEnvironmentVariable
 
 def generate_launch_description():
     # Package Directories    
@@ -13,7 +13,7 @@ def generate_launch_description():
     world_name = os.path.join(get_package_share_directory('racecar_gazebo'), 'worlds', 'racecar_circuit.world')
     racecar_gazebo = os.path.join(get_package_share_directory('racecar_gazebo'))
 
-    gazeboDefaultResourcePath = SetEnvironmentVariable(name="GZ_SIM_RESOURCE_PATH", "/opt/ros/jazzy/share")
+    gazeboDefaultResourcePath = AppendEnvironmentVariable("GZ_SIM_RESOURCE_PATH", "/opt/ros/jazzy/share")
     addRacecarGazeboResourcePath = AppendEnvironmentVariable("GZ_SIM_RESOURCE_PATH", racecar_gazebo)
 
 

--- a/racecar_gazebo/launch/racecar_circuit.launch.py
+++ b/racecar_gazebo/launch/racecar_circuit.launch.py
@@ -3,7 +3,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.actions import AppendEnvironmentVariable
+from launch.actions import AppendEnvironmentVariable, SetEnvironmentVariable
 
 def generate_launch_description():
     # Package Directories    
@@ -11,9 +11,10 @@ def generate_launch_description():
     racecar_gazebo = get_package_share_directory('racecar_gazebo')
 
     world_name = os.path.join(get_package_share_directory('racecar_gazebo'), 'worlds', 'racecar_circuit.world')
-    models_path = os.path.join(get_package_share_directory('racecar_gazebo'))
+    racecar_gazebo = os.path.join(get_package_share_directory('racecar_gazebo'))
 
-    addEnvVariable = AppendEnvironmentVariable("IGN_GAZEBO_RESOURCE_PATH",models_path)
+    gazeboDefaultResourcePath = SetEnvironmentVariable(name="GZ_SIM_RESOURCE_PATH", "/opt/ros/jazzy/share")
+    addRacecarGazeboResourcePath = AppendEnvironmentVariable("GZ_SIM_RESOURCE_PATH", racecar_gazebo)
 
 
     # Inside generate_launch_description() function
@@ -30,7 +31,8 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        addEnvVariable,
+        gazeboDefaultResourcePath,
+        addRacecarGazeboResourcePath,
         gazebo,
         spawn,
     ])


### PR DESCRIPTION
This commit attempts to fix issues with Gazebo for GRO830's lab by reverting changes made in A24.

NOTES:

- As required when migrating from Ignition to Gazebo, the environment variable for Gazebo's ressource path's prefix is changed to "GZ_SIM".
- (2025-09-18) This commit is awaiting testing: do NOT merge yet!