### PR TITLE
Replace hard-coded, mode dependent values for axis and button names

### DIFF
--- a/doc/joy_mappings.md
+++ b/doc/joy_mappings.md
@@ -1,0 +1,64 @@
+# Joystick Controller Mappings
+
+These are the default mappings for `joy_node`.
+
+## Xbox Series X Controller
+
+| Axis | ID  | Name                        |
+| ---- | --- | ----------------------------|
+| 0    | LJH | Left Joystick (Horizontal)  |
+| 1    | LJV | Left Joystick (Vertical)    |
+| 2    | LT  | Left Trigger                |
+| 3    | RJH | Right Joystick (Horizontal) |
+| 4    | RJV | Right Joystick (Vertical)   |
+| 5    | RT  | Right Trigger               |
+| 6    | DPH | D-Pad (Horizontal)          |
+| 7    | DPV | D-Pad (Vertical)            |
+
+| Button | ID    | Name                     |
+| ------ | ----- | ------------------------ |
+| 0      | A     | A                        |
+| 1      | B     | B                        |
+| 2      | X     | X                        |
+| 3      | Y     | Y                        |
+| 4      | LB    | Left Bumper              |
+| 5      | RB    | Right Bumper             |
+| 6      | BACK  | Back/Select              |
+| 7      | START | Start                    |
+| 8      | HOME  | Home                     |
+| 9      | LJP   | Left Joystick (Pressed)  |
+| 10     | RJP   | Right Joystick (Pressed) |
+| 11     | M1    | Share                    |
+
+## Logitech F710
+
+### DirectInput
+
+TODO
+
+### XInput
+
+| Axis | ID  | Name                        |
+| ---- | --- | ----------------------------|
+| 0    | LJH | Left Joystick (Horizontal)  |
+| 1    | LJV | Left Joystick (Vertical)    |
+| 2    | LT  | Left Trigger                |
+| 3    | RJH | Right Joystick (Horizontal) |
+| 4    | RJV | Right Joystick (Vertical)   |
+| 5    | RT  | Right Trigger               |
+| 6    | DPH | D-Pad (Horizontal)          |
+| 7    | DPV | D-Pad (Vertical)            |
+
+| Button | ID    | Name                     |
+| ------ | ----- | ------------------------ |
+| 0      | A     | A                        |
+| 1      | B     | B                        |
+| 2      | X     | X                        |
+| 3      | Y     | Y                        |
+| 4      | LB    | Left Bumper              |
+| 5      | RB    | Right Bumper             |
+| 6      | BACK  | Back/Select              |
+| 7      | START | Start                    |
+| 8      | HOME  | Home                     |
+| 9      | LJP   | Left Joystick (Pressed)  |
+| 10     | RJP   | Right Joystick (Pressed) |

--- a/doc/joy_mappings.md
+++ b/doc/joy_mappings.md
@@ -28,13 +28,37 @@ These are the default mappings for `joy_node`.
 | 8      | HOME  | Home                     |
 | 9      | LJP   | Left Joystick (Pressed)  |
 | 10     | RJP   | Right Joystick (Pressed) |
-| 11     | M1    | Share                    |
+| 11     | M1    | Share\*                  |
+
+> \* Not all controllers have this button.
 
 ## Logitech F710
 
 ### DirectInput
 
-TODO
+| Axis | ID  | Name                        |
+| ---- | --- | ----------------------------|
+| 0    | LJH | Left Joystick (Horizontal)  |
+| 1    | LJV | Left Joystick (Vertical)    |
+| 2    | RJH | Right Joystick (Horizontal) |
+| 3    | RJV | Right Joystick (Vertical)   |
+| 4    | DPH | D-Pad (Horizontal)          |
+| 5    | DPV | D-Pad (Vertical)            |
+
+| Button | ID    | Name                     |
+| ------ | ----- | ------------------------ |
+| 0      | X     | X                        |
+| 1      | A     | A                        |
+| 2      | B     | B                        |
+| 3      | Y     | Y                        |
+| 4      | LB    | Left Bumper              |
+| 5      | RB    | Right Bumper             |
+| 6      | LT    | Left Trigger             |
+| 7      | RT    | Right Trigger            |
+| 8      | BACK  | Back/Select              |
+| 9      | START | Start                    |
+| 10     | LJP   | Left Joystick (Pressed)  |
+| 11     | RJP   | Right Joystick (Pressed) |
 
 ### XInput
 
@@ -62,3 +86,14 @@ TODO
 | 8      | HOME  | Home                     |
 | 9      | LJP   | Left Joystick (Pressed)  |
 | 10     | RJP   | Right Joystick (Pressed) |
+
+### `Mode` button
+
+The `Mode` toggle button swaps the left joystick and the D-Pad's indices. In other words:
+
+- LJH <---> DPH;
+- LJV <---> DPV.
+
+Additionally, the left joystick now behaves as a D-Pad.
+
+This feature works identically in both input modes.

--- a/racecar_teleop/racecar_teleop/slash_teleop.py
+++ b/racecar_teleop/racecar_teleop/slash_teleop.py
@@ -1,157 +1,220 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import rclpy
 from rclpy.node import Node
-import numpy as np
 from sensor_msgs.msg import Joy
 from geometry_msgs.msg import Twist
 
 
-#########################################
 class Teleop(Node):
     """
-    teleoperation
+    This class takes inputs from `joy_node`, and converts them into commands
+    sent to the autopilot controller.
     """
+
     def __init__(self):
+        super().__init__("teleop")
 
-        super().__init__('Teleop')
+        self.max_vel = (
+            self.declare_parameter("max_vel", 4.0).get_parameter_value().double_value
+        )
+        self.max_volt = (
+            self.declare_parameter("max_volt", 8.0).get_parameter_value().double_value
+        )
+        self.maxStAng = (
+            self.declare_parameter("max_angle", 40).get_parameter_value().double_value
+        )
+        self.ps4 = self.declare_parameter("ps4", False).get_parameter_value().bool_value
+        self.input_mode = (
+            self.declare_parameter("input_mode", "X").get_parameter_value().string_value
+        )  # X: XInput, D: DirectInput
 
-
-        self.max_vel = self.declare_parameter('max_vel', 4.0).value
-        self.max_volt = self.declare_parameter('max_volt', 8.0).value
-        self.maxStAng = self.declare_parameter('max_angle', 40).value
-        self.ps4 = self.declare_parameter('ps4', False).value
-
-        self.cmd2rad   = self.maxStAng*2*3.1416/360
+        self.cmd2rad = self.maxStAng * 2 * 3.141592 / 360
         self.joystickCompatibilityWarned = False
 
+        self.pub_cmd = self.create_publisher(Twist, "ctl_ref", 1)
 
-        self.pub_cmd = self.create_publisher(Twist, 'ctl_ref', 1)
-        
         # Always create subscribers last
-        self.sub_joy = self.create_subscription(Joy, 'joy', self.joy_callback, 1)
+        self.sub_joy = self.create_subscription(Joy, "joy", self.joy_callback, 1)
 
-        
+        self.axes: dict[str, float] = {
+            "LJH": -1.0,
+            "LJV": -1.0,
+            "RJH": -1.0,
+            "RJV": -1.0,
+            "LT": -1.0,
+            "RT": -1.0,
+            "DPH": 0.0,
+            "DPV": 0.0,
+        }
 
-    ####################################### 
-        
-    def joy_callback( self, joy_msg ):
-        """ """
+        self.buttons: dict[str, bool] = {
+            "A": False,
+            "B": False,
+            "X": False,
+            "Y": False,
+            "LB": False,
+            "RB": False,
+            "BACK": False,
+            "START": False,
+            "HOME": False,
+            "LJP": False,
+            "RJP": False,
+        }
+
+    def __get_inputs(self, msg: Joy):
+        if self.input_mode == "X":
+            self.axes["LJH"] = msg.axes[0]
+            self.axes["LJV"] = msg.axes[1]
+            self.axes["RJH"] = msg.axes[2]
+            self.axes["RJV"] = msg.axes[3]
+            self.axes["LT"] = msg.axes[4]
+            self.axes["RT"] = msg.axes[5]
+            self.axes["DPH"] = msg.axes[6]
+            self.axes["DPH"] = msg.axes[7]
+
+            self.buttons["A"] = bool(msg.buttons[0])
+            self.buttons["B"] = bool(msg.buttons[1])
+            self.buttons["X"] = bool(msg.buttons[2])
+            self.buttons["Y"] = bool(msg.buttons[3])
+            self.buttons["LB"] = bool(msg.buttons[4])
+            self.buttons["RB"] = bool(msg.buttons[5])
+            self.buttons["BACK"] = bool(msg.buttons[6])
+            self.buttons["START"] = bool(msg.buttons[7])
+            self.buttons["HOME"] = bool(msg.buttons[8])
+            self.buttons["LJP"] = bool(msg.buttons[9])
+            self.buttons["RJP"] = bool(msg.buttons[10])
+        elif self.ps4 or self.input_mode == "D":
+            self.axes["LJH"] = msg.axes[0]
+            self.axes["LJV"] = msg.axes[1]
+            self.axes["RJH"] = msg.axes[2]
+            self.axes["RJV"] = msg.axes[3]
+            self.axes["DPH"] = msg.axes[4]
+            self.axes["DPH"] = msg.axes[5]
+
+            self.axes["LT"] = msg.buttons[6]
+            self.axes["RT"] = msg.buttons[7]
+
+            self.buttons["A"] = bool(msg.buttons[1])
+            self.buttons["B"] = bool(msg.buttons[2])
+            self.buttons["X"] = bool(msg.buttons[0])
+            self.buttons["Y"] = bool(msg.buttons[3])
+            self.buttons["LB"] = bool(msg.buttons[4])
+            self.buttons["RB"] = bool(msg.buttons[5])
+            self.buttons["BACK"] = bool(msg.buttons[8])
+            self.buttons["START"] = bool(msg.buttons[9])
+            self.buttons["LJP"] = bool(msg.buttons[10])
+            self.buttons["RJP"] = bool(msg.buttons[11])
+        else:
+            raise ValueError(
+                f"Invalid value for parameter `input_mode`: {self.input_mode}"
+            )
+
+    def joy_callback(self, msg: Joy):
         min_axes = 5 if self.ps4 else 4
-        if len(joy_msg.axes) < min_axes or len(joy_msg.buttons) < 7:
+        if len(msg.axes) < min_axes or len(msg.buttons) < 7:
             if not self.joystickCompatibilityWarned:
-                self.get_logger().info("slash_teleop: Received topic doesn't have enough axes and/or buttons. If a Logitech gamepad is used, make sure also it is in X mode. Will not warn again.")
+                self.get_logger().info(
+                    "slash_teleop: Received topic doesn't have enough axes and/or buttons. If a Logitech gamepad is used, make sure also it is in X mode. Will not warn again."
+                )
                 self.joystickCompatibilityWarned = True
             return
 
-        self.joystickCompatibilityWarned = False   # reset in case we switch mode on the gamepad
+        self.joystickCompatibilityWarned = (
+            False  # reset in case we switch mode on the gamepad
+        )
 
-        propulsion_user_input = joy_msg.axes[3]    # Up-down Right joystick 
-        steering_user_input   = joy_msg.axes[0]    # Left-right left joystick
-        
-        self.cmd_msg = Twist()             
-                
-        # Software deadman switch
-        #If left button is active 
-        if (joy_msg.buttons[4]):
-            
-            #No button pressed (see below)
-            # Closed-loop velocity, Open-loop steering, control mode = 0
-            
-            #If right button is active       
-            if (joy_msg.buttons[5]):   
-                # Fully Open-Loop
-                self.cmd_msg.linear.x  = propulsion_user_input * self.max_volt #[volts]
+        self.__get_inputs(msg)
+
+        propulsion_user_input = self.axes["RJV"]  # Right joystick vertical
+        steering_user_input = self.axes["LJH"]  # Left joystick horizontal
+
+        self.cmd_msg = Twist()
+
+        # "Poor man's deadman switch"
+        if self.buttons["LB"]:
+            # If right button is active
+            if self.buttons["RB"]:
+                # Fully Open-Loop (WARNING: may result in crashes)
+                self.cmd_msg.linear.x = propulsion_user_input * self.max_volt  # V
                 self.cmd_msg.angular.z = steering_user_input * self.cmd2rad
-                self.cmd_msg.linear.z  = 1.0   #CtrlChoice
-            
-            elif (joy_msg.buttons[10]): # RJP
+                self.cmd_msg.linear.z = 1.0  # CtrlChoice
+
+            elif self.buttons["RJP"]:
                 """
                 GRO501-1: closed-loop velocity fixed @ X m/s, open-loop
                 steering, where X is determined "on-site".
                 """
-                self.cmd_msg.linear.x = 2.0 # m/s
+                self.cmd_msg.linear.x = 2.0  # m/s
                 self.cmd_msg.angular.z = steering_user_input * self.cmd2rad
-                self.cmd_msg.linear.z = 0.0 # high-level mode
-                
-            #If right trigger is active       
-            elif (joy_msg.buttons[7]):   # START
+                self.cmd_msg.linear.z = 0.0  # high-level mode
+
+            # If right trigger is active
+            elif self.buttons["START"]:
                 """
                 GRO501-1: closed-loop position fixed @ X m, open-loop
                 steering, where X is determined "on-site".
                 """
-                self.cmd_msg.linear.x  = 2.0 # [m]
+                self.cmd_msg.linear.x = 2.0  # [m]
                 self.cmd_msg.angular.z = steering_user_input * self.cmd2rad
-                self.cmd_msg.linear.z  = 2.0   #CtrlChoice
-                
-            #If button A is active 
-            elif(joy_msg.buttons[1]):   
-                # Closed-loop velocity, Closed-loop steering 
-                self.cmd_msg.linear.x  = propulsion_user_input * self.max_vel #[m/s]
-                self.cmd_msg.angular.z = steering_user_input # [m]
-                self.cmd_msg.linear.z  = 3.0  # Control mode
-                
-            #If button B is active 
-            elif(joy_msg.buttons[2]):   
-                # Closed-loop position, Closed-loop steering 
-                self.cmd_msg.linear.x  = propulsion_user_input # [m]
-                self.cmd_msg.angular.z = steering_user_input # [m]
-                self.cmd_msg.linear.z  = 4.0  # Control mode
-                
-            #If button x is active 
-            elif(joy_msg.buttons[0]):   
+                self.cmd_msg.linear.z = 2.0  # CtrlChoice
+
+            elif self.buttons["A"]:
+                # Closed-loop velocity, Closed-loop steering
+                self.cmd_msg.linear.x = propulsion_user_input * self.max_vel  # [m/s]
+                self.cmd_msg.angular.z = steering_user_input  # [m]
+                self.cmd_msg.linear.z = 3.0  # Control mode
+
+            elif self.buttons["B"]:
+                # Closed-loop position, Closed-loop steering
+                self.cmd_msg.linear.x = propulsion_user_input  # [m]
+                self.cmd_msg.angular.z = steering_user_input  # [m]
+                self.cmd_msg.linear.z = 4.0  # Control mode
+
+            elif self.buttons["X"]:
                 # Closed-loop velocity with fixed 1 m/s ref, Closed-loop steering
-                self.cmd_msg.linear.x  = 2.0 #[m/s]
-                self.cmd_msg.angular.z = 0.0 # [m]
-                self.cmd_msg.linear.z  = 5.0 # Control mode
-                
-            #If button y is active 
-            elif(joy_msg.buttons[3]):   
+                self.cmd_msg.linear.x = 2.0  # [m/s]
+                self.cmd_msg.angular.z = 0.0  # [m]
+                self.cmd_msg.linear.z = 5.0  # Control mode
+
+            elif self.buttons["Y"]:
                 # Reset Encoder
-                self.cmd_msg.linear.x  = 0.0
+                self.cmd_msg.linear.x = 0.0
                 self.cmd_msg.angular.z = 0.0
-                self.cmd_msg.linear.z  = 6.0  # Control mode
-                
-            #If left trigger is active 
-            elif (joy_msg.buttons[6]):
-                # No ctl_ref msg published!
+                self.cmd_msg.linear.z = 6.0  # Control mode
+
+            elif (
+                self.axes["LT"] >= 0.0
+                if (self.ps4 or self.input_mode == "D")
+                else self.axes["LT"] <= 0.0
+            ):
+                # Joystick deactivated. No reference published.
                 return
-                
-            #If right joy pushed
-            # elif(joy_msg.buttons[11]):
-            #      # Template for a custom mode
+
+            # Template for a custom mode
+            # elif(self.buttons[<ID>]):
             #     self.cmd_msg.linear.x  = 0.0
             #     self.cmd_msg.angular.z = 0.0
             #     self.cmd_msg.linear.z  = 7.0 # Control mode
-                
-            #If bottom arrow is active
-            # elif(joy_msg.axes[7]):
-            #     # Template for a custom mode
-            #     self.cmd_msg.linear.x  = 0.0
-            #     self.cmd_msg.angular.z = 0.0
-            #     self.cmd_msg.linear.z  = 8.0 # Control mode
 
-            # Defaults operation
-            # No active button
             else:
-                # Closed-loop velocity, Open-loop steering
-                self.cmd_msg.linear.x  = propulsion_user_input * self.max_vel #[m/s]
+                # Open-loop velocity (saturated), Open-loop steering
+                self.cmd_msg.linear.x = propulsion_user_input * self.max_vel  # [m/s]
                 self.cmd_msg.angular.z = steering_user_input * self.cmd2rad
-                self.cmd_msg.linear.z  = 7.0  # Control mode
-        
-        # Deadman is un-pressed
+                self.cmd_msg.linear.z = 7.0  # Control mode
+
         else:
             # All-stop
-            self.cmd_msg.linear.x = 0.0 
+            self.cmd_msg.linear.x = 0.0
             self.cmd_msg.linear.y = 0.0
-            self.cmd_msg.linear.z = -1.0            
+            self.cmd_msg.linear.z = -1.0
             self.cmd_msg.angular.x = 0.0
             self.cmd_msg.angular.y = 0.0
-            self.cmd_msg.angular.z = 0.0 
+            self.cmd_msg.angular.z = 0.0
 
+        self.pub_cmd.publish(self.cmd_msg)
 
-        # Publish cmd msg
-        self.pub_cmd.publish( self.cmd_msg )
-            
 
 def main(args=None):
     rclpy.init(args=args)
@@ -159,6 +222,6 @@ def main(args=None):
     rclpy.spin(node)
     rclpy.shutdown()
 
-##############
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
The motivation for this commit stems from the discrepancies between the input modes of the Logitech F710 controller (DirectInput and XInput), potentially causing confusion when trying to teleoperate the racecar.

Instead of directly reading the values from the `Joy` msg in the callback, a local dictionary containing the values of the axes and the buttons is updated before going through the logic of the callback. This abstraction SHOULD make it so the same input in both input modes result in the same command\*\* sent to the controller.

> \*\* Since the triggers are treated as buttons in DirectInput mode,
> a command using the analog value of a trigger will not be equivalent
> in both modes.

The ROS parameter `input_mode` is added to the node to specify the input mode. **IMPORTANT**: the input mode does NOT update automatically if the input mode is changed on the F710 or if a new controller is used.

CHANGES:

- Add node argument `input_mode` to specify the input mode;
- Add (local) axes and buttons dictionaries;
- Add dictionary update function;
- Replace hard-coded `msg.<category>[<ID>]` with mode-independant values;
- Auto-format the `teleop` node file;
- Add mappings for the Xbox One Controller and Logitech F710 (XInput) in the documentation:
  - The DirectInput mappings WILL be added in an ulterior commit (I currently don't have a F710 to test the mappings);