### PR TITLE
Add bypass option for joy

### DIFF
--- a/racecar_bringup/racecar_bringup/cmd_vel_arbitration.py
+++ b/racecar_bringup/racecar_bringup/cmd_vel_arbitration.py
@@ -14,6 +14,11 @@ class Arbitration(Node):
         self._delay_sec = (
             self.declare_parameter("delay_sec", 0.5).get_parameter_value().double_value
         )
+        
+        self._bypass_joy = (
+            self.declare_parameter("bypass_joy", False).get_parameter_value().bool_value
+        )
+        
         self._time_called = [self.get_clock().now() for _ in range(9)]
 
         self._cmd_vel_pub = self.create_publisher(Twist, "cmd_vel_output", 1)
@@ -50,7 +55,7 @@ class Arbitration(Node):
                 pub = False
                 break
         if pub:
-            if self.__autopilot_active:
+            if self.__autopilot_active or self._bypass_joy:
                 self._cmd_vel_pub.publish(msg)
             elif priority == 0:
                 self._cmd_vel_pub.publish(msg)

--- a/racecar_gazebo/launch/simulation.launch.py
+++ b/racecar_gazebo/launch/simulation.launch.py
@@ -38,6 +38,7 @@ def launch_setup(context: LaunchContext, *args, **kwargs):
         PythonLaunchDescriptionSource(
             [os.path.join(racecar_gazebo, "launch", "spawn_racecar.launch.py")]
         ),
+        launch_arguments={"use_joy": LaunchConfiguration('use_joy')}.items()
     )
 
     return (gazeboDefaultResourcePath, addRacecarGazeboResourcePath, gazebo, spawn_racecar)
@@ -51,4 +52,6 @@ def generate_launch_description():
         choices=["tunnel", "tunnel_genie", "circuit"],
     )
 
-    return LaunchDescription([world_arg, OpaqueFunction(function=launch_setup)])
+    return LaunchDescription([DeclareLaunchArgument('use_joy', default_value='True', description="launch joy related node"),
+                              world_arg, 
+                              OpaqueFunction(function=launch_setup)])

--- a/racecar_gazebo/launch/spawn_racecar.launch.py
+++ b/racecar_gazebo/launch/spawn_racecar.launch.py
@@ -92,10 +92,6 @@ def launch_setup(context, *args, **kwargs):
     )
 
 
-    # gaz_control = IncludeLaunchDescription(
-    #     PythonLaunchDescriptionSource([os.path.join(racecar_gazebo, 'launch', 'gazebo_control.launch.py')]),
-    # )  # NOTE: Does nothing.
-
     kalmanFilter = IncludeLaunchDescription(
                         PythonLaunchDescriptionSource([os.path.join(racecar_navigation, 'launch', 'kalmanFilter.launch.py')]),
                         launch_arguments={"odom_topic":f'/{prefix}/odom/filtered',
@@ -110,7 +106,6 @@ def launch_setup(context, *args, **kwargs):
         cmd_vel_arb,
         joystick,
         teleop,
-        # gaz_control,
         kalmanFilter
     ]
 

--- a/racecar_gazebo/launch/spawn_racecar.launch.py
+++ b/racecar_gazebo/launch/spawn_racecar.launch.py
@@ -4,6 +4,7 @@ import xacro
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, OpaqueFunction
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -11,12 +12,12 @@ from xml.dom.minidom import Document
 
 
 def launch_setup(context, *args, **kwargs):
-    # Declare launch arguments
+    # Get launch arguments
     prefix = LaunchConfiguration('prefix').perform(context)
+    use_joy = LaunchConfiguration('use_joy').perform(context).lower() == "true"
 
     # Package Directories
     racecar_description = get_package_share_directory('racecar_description')
-    # racecar_gazebo = get_package_share_directory('racecar_gazebo')  # NOTE: Unused.
     racecar_navigation = get_package_share_directory('racecar_navigation')
 
     # Parse robot description from xacro
@@ -68,6 +69,7 @@ def launch_setup(context, *args, **kwargs):
     cmd_vel_arb = Node(
         package='racecar_bringup',
         executable='cmd_vel_arbitration',
+        parameters=[{'bypass_joy': not use_joy}],
         remappings=[(f'/{prefix}/cmd_vel_output', f'/{prefix}/cmd_vel')],
         namespace=prefix
     )
@@ -79,7 +81,8 @@ def launch_setup(context, *args, **kwargs):
         parameters=[{'deadzone': 0.2},
                     {'autorepeat_rate': 0.0},
                     {'coalesce_interval': 0.01}],
-        namespace=prefix
+        namespace=prefix,
+        condition=IfCondition(LaunchConfiguration('use_joy'))
     )
 
 
@@ -88,7 +91,8 @@ def launch_setup(context, *args, **kwargs):
             executable='slash_teleop',
             name='racecar_teleop',
             remappings=[(f'/{prefix}/ctl_ref', f'/{prefix}/cmd_vel_abtr_0')],
-            namespace=prefix   
+            namespace=prefix,
+            condition=IfCondition(LaunchConfiguration('use_joy'))
     )
 
 
@@ -113,6 +117,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         DeclareLaunchArgument('prefix', default_value='racecar'),
+        DeclareLaunchArgument('use_joy', default_value='True', description="launch joy related node"),
         OpaqueFunction(function=launch_setup)
     ])
 


### PR DESCRIPTION
The new feature enforcing the use of the Deadman switch in the arbitration node makes the navigation stack unusable when the user does not have access to a controller. To fix this issue, I added a bypass parameter. The bypass option is default to false so there is no change in the behavior of the arbitration when not used

to launch the simulation with the arbitration bypass set the use_joy argument to false as follow
`ros2 launch racecar_gazebo simulation.launch.py use_joy:=false
`