### PR TITLE
55 unexpected steering inversion when driving in reverse using teleop

### DIFF
--- a/racecar_description/config/ros_bridge.yaml
+++ b/racecar_description/config/ros_bridge.yaml
@@ -4,8 +4,8 @@
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "/racecar/cmd_vel"
-  gz_topic_name: "/racecar/cmd_vel"
+- ros_topic_name: "/racecar/cmd_vel_to_gz"
+  gz_topic_name: "/racecar/cmd_vel_to_gz"
   ros_type_name: "geometry_msgs/msg/Twist"
   gz_type_name: "gz.msgs.Twist"
   direction: ROS_TO_GZ

--- a/racecar_description/urdf/racecar.gazebo
+++ b/racecar_description/urdf/racecar.gazebo
@@ -86,7 +86,7 @@
       <wheel_base>0.325</wheel_base>
       <wheel_radius>0.05</wheel_radius>
       <steering_limit>0.667</steering_limit>
-      <topic>$(arg prefix)/cmd_vel</topic>
+      <topic>$(arg prefix)/cmd_vel_to_gazebo</topic>
       <child_frame_id>$(arg prefix)/base_footprint</child_frame_id>
       <publish_tf>false</publish_tf>
       <tf_topic>$(arg prefix)/odom/tf</tf_topic>

--- a/racecar_description/urdf/racecar.gazebo
+++ b/racecar_description/urdf/racecar.gazebo
@@ -86,7 +86,7 @@
       <wheel_base>0.325</wheel_base>
       <wheel_radius>0.05</wheel_radius>
       <steering_limit>0.667</steering_limit>
-      <topic>$(arg prefix)/cmd_vel_to_gazebo</topic>
+      <topic>$(arg prefix)/cmd_vel_to_gz</topic>
       <child_frame_id>$(arg prefix)/base_footprint</child_frame_id>
       <publish_tf>false</publish_tf>
       <tf_topic>$(arg prefix)/odom/tf</tf_topic>

--- a/racecar_gazebo/launch/spawn_racecar.launch.py
+++ b/racecar_gazebo/launch/spawn_racecar.launch.py
@@ -94,6 +94,13 @@ def launch_setup(context, *args, **kwargs):
             namespace=prefix,
             condition=IfCondition(LaunchConfiguration('use_joy'))
     )
+    gazebo_cmd = Node(
+        package='racecar_gazebo',
+        executable='cmd_vel_to_gazebo',
+        name='cmd_vel_to_gazebo',
+        namespace=prefix,
+        condition=IfCondition(LaunchConfiguration('use_joy'))
+    )
 
 
     kalmanFilter = IncludeLaunchDescription(
@@ -110,6 +117,7 @@ def launch_setup(context, *args, **kwargs):
         cmd_vel_arb,
         joystick,
         teleop,
+        gazebo_cmd,
         kalmanFilter
     ]
 

--- a/racecar_gazebo/racecar_gazebo/cmd_vel_to_gazebo.py
+++ b/racecar_gazebo/racecar_gazebo/cmd_vel_to_gazebo.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# cmd_vel_shim.py
+import math, rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import Twist
+
+
+class CmdVelGazebo(Node):
+  def __init__(self):
+    super().__init__('cmd_vel_gz')
+    self.declare_parameter('wheelbase', 0.325)  # match your <wheel_base> in Gazebo
+    self.L = float(self.get_parameter('wheelbase').value)
+
+    # After-arbitration input (final command)
+    self.sub = self.create_subscription(Twist, '/racecar/cmd_vel', self.callback, 10)
+    # Output to bridge (choose either overwrite or a new topic)
+    self.pub = self.create_publisher(Twist, '/racecar/cmd_vel_to_gz', 10)
+
+  def callback(self, m):
+    out = Twist()
+    out.linear.x = m.linear.x
+    if m.linear.x < 0.0 :
+      out.angular.z = -m.angular.z
+    else:
+      out.angular.z = m.angular.z
+
+    self.pub.publish(out)
+
+
+def main():
+  rclpy.init()
+  rclpy.spin(CmdVelGazebo())
+  rclpy.shutdown()
+
+
+if __name__ == '__main__':
+  main()
+
+
+

--- a/racecar_gazebo/racecar_gazebo/cmd_vel_to_gazebo.py
+++ b/racecar_gazebo/racecar_gazebo/cmd_vel_to_gazebo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# cmd_vel_shim.py
+
 import math, rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist
@@ -7,7 +7,7 @@ from geometry_msgs.msg import Twist
 
 class CmdVelGazebo(Node):
   def __init__(self):
-    super().__init__('cmd_vel_gz')
+    super().__init__('cmd_vel_gazebo')
     self.declare_parameter('wheelbase', 0.325)  # match your <wheel_base> in Gazebo
     self.L = float(self.get_parameter('wheelbase').value)
 

--- a/racecar_gazebo/setup.py
+++ b/racecar_gazebo/setup.py
@@ -49,6 +49,7 @@ setup(
     entry_points={
         'console_scripts': [
             'cmd_vel_to_ackermann_drive = racecar_gazebo.cmd_vel_to_ackermann_drive:main',
+            'cmd_vel_to_gazebo = racecar_gazebo.cmd_vel_to_gazebo:main',
             'servo_commands = racecar_gazebo.servo_commands:servo_commands',
             'gazebo_odometry = racecar_gazebo.gazebo_odometry:main'
         ],


### PR DESCRIPTION
This bug isn't really a bug from our code but mainly from how gazebo use the command. From my understanding, the code in racecar_gazebo isn't completed (cmd_vel_to_ackermann, gazebo_odometry and servo_commands) aren't use.

As a hotfix, i made a node  that will make the command (driver-centric). I tested it on gazebo, steering is not reversed with this fix.

Maybe to be discussed on what was the purpose of thoses files in racecar_gazebo ( maybe i'm wrong )